### PR TITLE
Add installation script, proxy server support, and configurable diff message for ChatGPT commit message hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
 .PHONY: install
 
+ifeq ($(shell uname),Darwin)
+  HOOKS_DIR = /usr/local/Homebrew/.git/hooks
+else
+  HOOKS_DIR = /usr/share/git-core/templates/hooks
+endif
+
 install:
 	@echo "Installing ChatGPT commit message hook..."
-	@sudo cp prepare-commit-msg /usr/share/git-core/templates/hooks/prepare-commit-msg
-	@sudo chmod +x /usr/share/git-core/templates/hooks/prepare-commit-msg
+	@sudo mkdir -p $(HOOKS_DIR)
+	@sudo cp prepare-commit-msg $(HOOKS_DIR)/
+	@sudo chmod +x $(HOOKS_DIR)/prepare-commit-msg
 	@echo "ChatGPT commit message hook installed successfully."
 
 install-local:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: install
+
+install:
+	@echo "Installing ChatGPT commit message hook..."
+	@sudo cp prepare-commit-msg /usr/share/git-core/templates/hooks/prepare-commit-msg
+	@sudo chmod +x /usr/share/git-core/templates/hooks/prepare-commit-msg
+	@echo "ChatGPT commit message hook installed successfully."
+
+install-local:
+	@echo "Installing ChatGPT commit message hook locally..."
+	@cp prepare-commit-msg .git/hooks/prepare-commit-msg
+	@chmod +x .git/hooks/prepare-commit-msg
+	@echo "ChatGPT commit message hook locally installed successfully."

--- a/README.md
+++ b/README.md
@@ -68,11 +68,10 @@ secret_key = MY_SECRET_KEY
 proxy= HTTP_PROXY
 max_changed_lines=80
 ```
-3. Install the hook:
+1. Install the hook:
 ```
-destination="/usr/share/git-core/templates/hooks/prepare-commit-msg"
-sudo wget https://raw.githubusercontent.com/tom-doerr/chatgpt_commit_message_hook/main/prepare-commit-msg -O $destination
-sudo chmod +x $destination
+git clone https://github.com/jsfs2019/chatgpt_commit_message_hook
+sudo make install
 ```
 
 This will set up the hook for all new repositories. 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to generate commit messages.
 
 ## How do I install it?
 ### Setup
-1. Install the OpenAI API package (`pip install openai`).
+1. Install packages (`pip install -r requirements.txt`).
 2. Create a file at `$XDG_CONFIG_HOME/openaiapirc` with your API keys.
 3. [optional] Add proxy server settings to the config file. Http proxy is supported only.
 4. [optional] The maximum number of changed lines in a commit. If the number of changed lines is greater than this value, the hook will send the result of git diff --cached --stat, otherwise it will send git diff --cached. The default value is 80.
@@ -71,6 +71,7 @@ max_changed_lines=80
 5. Install the hook:
 ```
 git clone https://github.com/jsfs2019/chatgpt_commit_message_hook
+cd chatgpt_commit_message_hook
 sudo make install
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,15 @@ to generate commit messages.
 ### Setup
 1. Install the OpenAI API package (`pip install openai`).
 2. Create a file at `$XDG_CONFIG_HOME/openaiapirc` with your API keys.
+3. [optional] Add proxy server settings to the config file. Http proxy is supported only.
+4. [optional] The maximum number of changed lines in a commit. If the number of changed lines is greater than this value, the hook will send the result of git diff --cached --stat, otherwise it will send git diff --cached. The default value is 80.
+
 For example:
 ```
 [openai]
 secret_key = MY_SECRET_KEY
+proxy= HTTP_PROXY
+max_changed_lines=80
 ```
 3. Install the hook:
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ secret_key = MY_SECRET_KEY
 proxy= HTTP_PROXY
 max_changed_lines=80
 ```
-1. Install the hook:
+5. Install the hook:
 ```
 git clone https://github.com/jsfs2019/chatgpt_commit_message_hook
 sudo make install

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -67,9 +67,7 @@ def get_full_diff(changes_dict):
         full_diff += diff_text
 
     return full_diff
-
 def get_openai_chat_response(prompt, model, api_key, proxy_server=None):
-    # print prompt
     # Set the URL of the OpenAI API endpoint
     url = "https://api.openai.com/v1/chat/completions"
 
@@ -79,7 +77,7 @@ def get_openai_chat_response(prompt, model, api_key, proxy_server=None):
         "Authorization": f"Bearer {api_key}"
     }
 
-    # Set the HTTP proxy for the requests library
+    # Set the HTTP proxy for the requests library, if provided
     proxies = {
         "http": proxy_server,
         "https": proxy_server
@@ -91,7 +89,7 @@ def get_openai_chat_response(prompt, model, api_key, proxy_server=None):
         "messages": prompt
     }
 
-    # Send the API request with the specified proxy server
+    # Send the API request with the specified proxy server, if provided
     response = requests.post(url, headers=headers, json=data, proxies=proxies)
 
     # Process the API response

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -4,6 +4,8 @@ import os
 import sys
 import configparser
 import requests
+import git
+
 
 COMMIT_MSG_FILE = sys.argv[1]
 #COMMIT_SOURCE = sys.argv[2]
@@ -18,7 +20,53 @@ current_commit_file_content = open(COMMIT_MSG_FILE, 'r').read()
 CONFIG_DIR = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
 API_KEYS_LOCATION = os.path.join(CONFIG_DIR, "openaiapirc")
 
+def count_staged_changes(repo_path="."):
+    # Open the repository
+    repo = git.Repo(repo_path)
 
+    # Get the Git index
+    index = repo.index
+
+    # Get the staged changes as a text diff
+    # staged_diff = repo.diff("HEAD", "index", create_patch=True)
+    staged_diff = index.diff("HEAD", create_patch=True, R=True)
+
+    changes_dict = {}
+    for diff in staged_diff:
+        diff_text = diff.diff.decode("utf-8")
+        added_lines = sum(1 for line in diff_text.splitlines() if line.startswith("+"))
+        deleted_lines = sum(1 for line in diff_text.splitlines() if line.startswith("-"))
+
+        # Save the change to the dictionary
+        changes_dict[diff.b_path] = (added_lines, deleted_lines, diff_text)
+    return changes_dict
+
+def get_staged_changes_summary(changes_dict, n):
+    # Check if the total number of changed lines is less than n
+    total_changed_lines = sum(added_lines + deleted_lines for _, (added_lines, deleted_lines, _) in changes_dict.items())
+    if total_changed_lines < n:
+        return get_full_diff(changes_dict)
+
+    # Generate the summary string
+    summary = ""
+    for file_path, (added_lines, deleted_lines, _) in changes_dict.items():
+        summary += f"{file_path} | {added_lines + deleted_lines} "
+        if added_lines > 0:
+            summary += "+" * added_lines
+        if deleted_lines > 0:
+            summary += "-" * deleted_lines
+        summary += "\n"
+
+    return summary
+
+
+def get_full_diff(changes_dict):
+    # Generate the full diff string
+    full_diff = ""
+    for _, (_, _, diff_text) in changes_dict.items():
+        full_diff += diff_text
+
+    return full_diff
 
 def get_openai_chat_response(prompt, model, api_key, proxy_server=None):
     # print prompt
@@ -93,10 +141,12 @@ def initialize_openai_api():
 
 
 api_key, proxy = initialize_openai_api()
+changes_dict = count_staged_changes()
+summary = get_staged_changes_summary(changes_dict, 80)
 
 messages = [
 {'role': 'system', 'content': 'You are a helpful assistant writes short git commit messages.'},
-{'role': 'user', 'content': f'{current_commit_file_content}\n\nWrite the commit message.'},
+{'role': 'user', 'content': f'{summary}\n\nWrite the commit message.'},
 ]
 
 # response = openai.ChatCompletion.create(

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -112,8 +112,9 @@ def create_template_ini_file():
     if not os.path.isfile(API_KEYS_LOCATION):
         with open(API_KEYS_LOCATION, "w") as f:
             f.write("[openai]\n")
-            # f.write("organization_id=\n")
             f.write("secret_key=\n")
+            f.write("proxy=\n")
+            f.write("max_changed_lines=\n")
 
         print("OpenAI API config file created at {}".format(API_KEYS_LOCATION))
         print("Please edit it and add your organization ID and secret key")
@@ -135,14 +136,27 @@ def initialize_openai_api():
     config.read(API_KEYS_LOCATION)
 
     # openai.organization_id = config["openai"]["organization_id"].strip('"').strip("'")
-    api_key = config["openai"]["secret_key"].strip('"').strip("'")
-    proxy = config["openai"]["proxy"].strip('"').strip("'")
-    return api_key, proxy
+    # Read the API key from the configuration
+    api_key = config.get("openai", {}).get("secret_key", "").strip('"').strip("'")
+    # Check if the API key is None
+    if api_key is None:
+        raise ValueError("OpenAI API key is not set in the configuration")
+    # Read the proxy from the configuration
+    proxy = config.get("openai", {}).get("proxy", "").strip('"').strip("'")
+    # Read the maximum number of changed lines from the configuration
+    max_changed_lines = config.get("openai", {}).get("max_changed_lines", "")
+    if max_changed_lines:
+        max_changed_lines = int(max_changed_lines)
+
+    # Check if the maximum number of changed lines is valid
+    if max_changed_lines is None or max_changed_lines <= 0:
+        max_changed_lines = 80
+    return api_key, proxy, max_changed_lines
 
 
-api_key, proxy = initialize_openai_api()
+api_key, proxy, max_changed_lines = initialize_openai_api()
 changes_dict = count_staged_changes()
-summary = get_staged_changes_summary(changes_dict, 80)
+summary = get_staged_changes_summary(changes_dict, max_changed_lines)
 
 messages = [
 {'role': 'system', 'content': 'You are a helpful assistant writes short git commit messages.'},

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -5,6 +5,7 @@ import sys
 import configparser
 import requests
 import git
+import re
 
 
 COMMIT_MSG_FILE = sys.argv[1]
@@ -63,8 +64,10 @@ def get_staged_changes_summary(changes_dict, n):
 def get_full_diff(changes_dict):
     # Generate the full diff string
     full_diff = ""
-    for _, (_, _, diff_text) in changes_dict.items():
-        full_diff += diff_text
+    for diff_path, (_, _, diff_text) in changes_dict.items():
+        full_diff += f"diff --git a/{diff_path} b/{diff_path}:\n"
+        full_diff += '\n'.join(filter(lambda line: re.match(r'^[+\-]', line), diff_text.split('\n')))
+        full_diff += "\n"
 
     return full_diff
 def get_openai_chat_response(prompt, model, api_key, proxy_server=None):
@@ -135,14 +138,14 @@ def initialize_openai_api():
 
     # openai.organization_id = config["openai"]["organization_id"].strip('"').strip("'")
     # Read the API key from the configuration
-    api_key = config.get("openai", {}).get("secret_key", "").strip('"').strip("'")
+    api_key = config["openai"]["secret_key"].strip('"').strip("'")
     # Check if the API key is None
     if api_key is None:
         raise ValueError("OpenAI API key is not set in the configuration")
     # Read the proxy from the configuration
-    proxy = config.get("openai", {}).get("proxy", "").strip('"').strip("'")
+    proxy = config["openai"]["proxy"].strip('"').strip("'")
     # Read the maximum number of changed lines from the configuration
-    max_changed_lines = config.get("openai", {}).get("max_changed_lines", "")
+    max_changed_lines = config["openai"]["max_changed_lines"]
     if max_changed_lines:
         max_changed_lines = int(max_changed_lines)
 
@@ -155,9 +158,8 @@ def initialize_openai_api():
 api_key, proxy, max_changed_lines = initialize_openai_api()
 changes_dict = count_staged_changes()
 summary = get_staged_changes_summary(changes_dict, max_changed_lines)
-
 messages = [
-{'role': 'system', 'content': 'You are a helpful assistant writes short git commit messages.'},
+{'role': 'system', 'content': 'You are a helpful assistant writes short git commit messages based on the git diff.'},
 {'role': 'user', 'content': f'{summary}\n\nWrite the commit message.'},
 ]
 

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -2,8 +2,8 @@
 
 import os
 import sys
-import openai
 import configparser
+import requests
 
 COMMIT_MSG_FILE = sys.argv[1]
 #COMMIT_SOURCE = sys.argv[2]
@@ -15,13 +15,43 @@ current_commit_file_content = open(COMMIT_MSG_FILE, 'r').read()
     # f.write(f'{commit_message}: ')
     # f.write(current_commit_file_content)
 
-
-
-
-
 CONFIG_DIR = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
 API_KEYS_LOCATION = os.path.join(CONFIG_DIR, "openaiapirc")
 
+
+
+def get_openai_chat_response(prompt, model, api_key, proxy_server=None):
+    # print prompt
+    # Set the URL of the OpenAI API endpoint
+    url = "https://api.openai.com/v1/chat/completions"
+
+    # Set the HTTP headers for the API request
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}"
+    }
+
+    # Set the HTTP proxy for the requests library
+    proxies = {
+        "http": proxy_server,
+        "https": proxy_server
+    } if proxy_server else None
+
+    # Set the data for the API request
+    data = {
+        "model": model,
+        "messages": prompt
+    }
+
+    # Send the API request with the specified proxy server
+    response = requests.post(url, headers=headers, json=data, proxies=proxies)
+
+    # Process the API response
+    if response.status_code == 200:
+        messages = response.json()["choices"][0]["message"]["content"]
+        return messages
+    else:
+        print("Error:", response.text)
 
 def create_template_ini_file():
     # """
@@ -57,26 +87,30 @@ def initialize_openai_api():
     config.read(API_KEYS_LOCATION)
 
     # openai.organization_id = config["openai"]["organization_id"].strip('"').strip("'")
-    openai.api_key = config["openai"]["secret_key"].strip('"').strip("'")
+    api_key = config["openai"]["secret_key"].strip('"').strip("'")
+    proxy = config["openai"]["proxy"].strip('"').strip("'")
+    return api_key, proxy
 
 
-initialize_openai_api()
+api_key, proxy = initialize_openai_api()
 
 messages = [
 {'role': 'system', 'content': 'You are a helpful assistant writes short git commit messages.'},
 {'role': 'user', 'content': f'{current_commit_file_content}\n\nWrite the commit message.'},
 ]
 
-response = openai.ChatCompletion.create(
+# response = openai.ChatCompletion.create(
+#     model="gpt-3.5-turbo",
+#     # model="text-davinci-003",
+#   messages=messages,
+# )
+# replace it with get_openai_chat_response
+response_text = get_openai_chat_response(
+    prompt=messages,
     model="gpt-3.5-turbo",
-    # model="text-davinci-003",
-  messages=messages,
+    api_key=api_key,
+    proxy_server=proxy,
 )
-
-# print("response:", response, flush=True)
-
-response_text = response["choices"][0]["message"]['content']
-# print("response_text:", response_text)
 
 
 content_whole_file = response_text + current_commit_file_content

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+GitPython==3.1.31
+requests==2.28.2


### PR DESCRIPTION
This pull request adds an installation script and several configuration options to the ChatGPT commit message hook. The changes include:

- Refactoring the code to use the requests library for the OpenAI chat API
- Adding support for counting the number of staged changes and generating a summary if the count exceeds a maximum value
- Refactoring the configuration reading to use a cleaner syntax
- Adding support for setting a maximum number of changed lines in a commit, with a default value of 80
- Adding instructions for setting up a proxy server for the OpenAI API and configuring the maximum number of changed lines
- Adding an installation script for the hook, which simplifies the installation process

These changes make the ChatGPT commit message hook more flexible and easier to install, configure, and use.