### PR TITLE
Update git hook to skip prepare-commit-msg during rebase and merge

### DIFF
--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -7,8 +7,9 @@ import requests
 import git
 import re
 
-if os.path.exists(".git/rebase-merge") or os.path.exists(".git/rebase-apply"):
+if os.path.exists(".git/rebase-merge") or os.path.exists(".git/rebase-apply") or os.path.exists(".git/MERGE_HEAD"):
     sys.exit(0)
+
 
 COMMIT_MSG_FILE = sys.argv[1]
 #COMMIT_SOURCE = sys.argv[2]

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -7,6 +7,8 @@ import requests
 import git
 import re
 
+if os.path.exists(".git/rebase-merge") or os.path.exists(".git/rebase-apply"):
+    sys.exit(0)
 
 COMMIT_MSG_FILE = sys.argv[1]
 #COMMIT_SOURCE = sys.argv[2]


### PR DESCRIPTION
If I try to rebase the branch or rebase interactively, the hook will trigger, I don't think we need this hook when using rebase.