### PR TITLE
Fix prepare-commit-msg hook to check for git directory in submodules

### DIFF
--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -7,7 +7,20 @@ import requests
 import git
 import re
 
-if os.path.exists(".git/rebase-merge") or os.path.exists(".git/rebase-apply") or os.path.exists(".git/MERGE_HEAD"):
+# check this repo is a submodule
+dir = ".git"
+if os.path.isfile(".git"):
+    with open(".git", "r") as f:
+        git_dir = f.read().split(" ")[1].strip()
+        dir = git_dir
+
+
+if (
+    os.path.exists(dir + "/rebase-merge")
+    or os.path.exists(dir + "/rebase-apply")
+    or os.path.exists(dir + "/MERGE_HEAD")
+    or os.path.exists(dir + "/CHERRY_PICK_HEAD")
+):
     sys.exit(0)
 
 


### PR DESCRIPTION
when I change code in submodule and try to rebase or cherrypick commits, it still run this hook. I found that as a submoudule, rebase-merg and other file is in main module dir, so I raised this PR and try to fix it